### PR TITLE
Only push the `ksync` binaries to release

### DIFF
--- a/testdata/ci/release.sh
+++ b/testdata/ci/release.sh
@@ -39,4 +39,4 @@ ghr \
   -b "$(cat ./CHANGELOG.md)" \
   -p 5 \
   -draft \
-  ${CIRCLE_TAG} bin/
+  ${CIRCLE_TAG} bin/ksync*


### PR DESCRIPTION
Limit releases to `ksync` only. Fixes #89 