### PR TITLE
Only override the pushed image if set

### DIFF
--- a/pkg/ksync/radar_test.go
+++ b/pkg/ksync/radar_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func init() {
-	SetImage(os.Getenv("IMAGE"))
+	if os.Getenv("IMAGE") != "" {
+		SetImage(os.Getenv("IMAGE"))
+	}
 }
 
 func TestNewRadarInstance(t *testing.T) {


### PR DESCRIPTION
We should only override the default image if the env var is set.