### PR TITLE
Cluster lost fix

### DIFF
--- a/pkg/ksync/spec.go
+++ b/pkg/ksync/spec.go
@@ -10,7 +10,6 @@ import (
 	"github.com/vapor-ware/ksync/pkg/debug"
 	"github.com/vapor-ware/ksync/pkg/ksync/cluster"
 	pb "github.com/vapor-ware/ksync/pkg/proto"
-	"github.com/vapor-ware/ksync/pkg/syncthing"
 )
 
 // SpecStatus is the status of a spec
@@ -106,8 +105,8 @@ func (s *Spec) Watch() error {
 				// case.
 				if event.Type == "" && event.Object == nil {
 					log.WithFields(s.Fields()).Error("lost connection to cluster")
-					s.Cleanup()
-					syncthing.SignalLoss <- true
+					SignalLoss <- true
+					return
 				}
 
 				if event.Object == nil {

--- a/pkg/ksync/syncthing.go
+++ b/pkg/ksync/syncthing.go
@@ -22,6 +22,7 @@ var (
 	duplicateListenerError = "Something is running on 8384 (run 'lsof -i :8384' to find out). Please stop that process before continuing."
 )
 
+// SignalLoss is a channel for communicating when contact with a cluster has been lost
 var SignalLoss = make(chan bool)
 
 // Syncthing represents the local syncthing process.
@@ -209,6 +210,7 @@ func (s *Syncthing) Run() error {
 			case <-SignalLoss:
 				log.WithFields(s.Fields()).Info("signal loss dectected. shutting down")
 				s.Stop()
+				os.Exit(1)
 				return
 			}
 		}
@@ -225,7 +227,6 @@ func (s *Syncthing) Run() error {
 // Stop halts the background process and cleans up.
 func (s *Syncthing) Stop() error {
 	defer s.cmd.Process.Wait() // nolint: errcheck
-	log.Debug("stopped sync")
 
-	return s.cmd.Process.Kill()
+	return s.cmd.Process.Signal(os.Interrupt)
 }

--- a/pkg/ksync/syncthing.go
+++ b/pkg/ksync/syncthing.go
@@ -225,6 +225,7 @@ func (s *Syncthing) Run() error {
 // Stop halts the background process and cleans up.
 func (s *Syncthing) Stop() error {
 	defer s.cmd.Process.Wait() // nolint: errcheck
+	log.Debug("stopped sync")
 
 	return s.cmd.Process.Kill()
 }

--- a/pkg/syncthing/server.go
+++ b/pkg/syncthing/server.go
@@ -2,7 +2,6 @@ package syncthing
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-resty/resty"
@@ -15,7 +14,6 @@ import (
 
 var connectRetries = 10
 
-var SignalLoss = make(chan bool)
 
 // Server represents a syncthing REST server. It is used to fetch and modify
 // configuration as well as restart the syncthing process.
@@ -50,19 +48,6 @@ func NewServer(host string, apikey string) (*Server, error) {
 	if err := server.Refresh(); err != nil {
 		return nil, err
 	}
-
-	// This is horrific, but spin off a process to check for signals about LOS
-	// (Loss Of Signal) from the cluster. Cleanup and bail if we get one.
-	go func() {
-		for {
-			select {
-			case <-SignalLoss:
-				log.WithFields(server.Fields()).Info("signal loss dectected. shutting down")
-				server.Stop()
-				os.Exit(1)
-			}
-		}
-	}()
 
 	return server, nil
 }


### PR DESCRIPTION
Fixes #143 

**tl;dr** When the tunnel to a cluster closes unexpectedly, `watch` loops continually. The loop stems from empty messages being streamed to a channel. See afbc00e for details.