### PR TITLE
cluster/client: add support for k8s OIDC auth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -830,6 +830,7 @@
     "pkg/util/parsers",
     "pkg/version",
     "plugin/pkg/client/auth/gcp",
+    "plugin/pkg/client/auth/oidc",
     "rest",
     "rest/watch",
     "third_party/forked/golang/template",
@@ -854,6 +855,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4649e1fd8dd9a74d9f572cd1f31a787e1dfa26d84a25035399f71c23228a85f1"
+  inputs-digest = "474a7cc7142f101a1c8e5ef56101174908e89be9e549380a43bfc503ef9f6164"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/ksync/cluster/client.go
+++ b/pkg/ksync/cluster/client.go
@@ -5,7 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Not sure why this is needed.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // for k8s using GCP auth
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // for k8s using OIDC auth
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
Attemping to run `ksync init` against a kubernetes cluster with a
kubectl context using OIDC authentication results the below error unless
ksync imports the k8s OIDC client auth plugin:

    $ ./bin/ksync init
    FATA[0000] No Auth Provider found for name "oidc"