### PR TITLE
REVERT: Temporarily removes the check on permissions.

### DIFF
--- a/pkg/input/sync_path.go
+++ b/pkg/input/sync_path.go
@@ -65,10 +65,11 @@ func (s *SyncPath) Validator() error {
 	if !filepath.IsAbs(s.Remote) {
 		return fmt.Errorf("remote path must be absolute")
 	}
-
-	if err := s.localPathHasPermission(); err != nil {
-		return err
-	}
+	// Removing this temporarily to ensure .git is not checked. See issue https://github.com/vapor-ware/ksync/issues/151 and https://github.com/vapor-ware/ksync/issues/127
+	//
+	// if err := s.localPathHasPermission(); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }

--- a/pkg/input/sync_path_test.go
+++ b/pkg/input/sync_path_test.go
@@ -74,6 +74,8 @@ func TestValidator(t *testing.T) {
 		Remote: os.TempDir(),
 	}
 	err = path.Validator()
-	assert.Error(t, err)
+	// Temporarily changed. See ./sync_path.go:68
+	// assert.Error(t, err)
+	assert.NoError(t, err)
 
 }


### PR DESCRIPTION
This temporarily removes the check on local path permissions to ensure they match the writability of remote paths. It is intended to solve https://github.com/vapor-ware/ksync/issues/151 until a better solution is implemented.

Note: My 🧠 hurts.

Closes #151 