### PR TITLE
Spec Creation Flood Protection

### DIFF
--- a/cmd/ksync/create.go
+++ b/cmd/ksync/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vapor-ware/ksync/pkg/cli"
 	"github.com/vapor-ware/ksync/pkg/input"
 	"github.com/vapor-ware/ksync/pkg/ksync"
+	"github.com/vapr-ware/ksync/pkg/ksync/doctor"
 )
 
 type createCmd struct {
@@ -132,6 +133,10 @@ func (cmd *createCmd) run(_ *cobra.Command, args []string) {
 		log.Fatalf("Could not create, --force to ignore: %v", err)
 	}
 
+	if err := doctor.IsWatchRunning(); err != nil {
+		log.Fatal(err)
+	}
+	
 	if err := specs.Save(); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/ksync/create.go
+++ b/cmd/ksync/create.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vapor-ware/ksync/pkg/cli"
 	"github.com/vapor-ware/ksync/pkg/input"
 	"github.com/vapor-ware/ksync/pkg/ksync"
-	"github.com/vapr-ware/ksync/pkg/ksync/doctor"
+	"github.com/vapor-ware/ksync/pkg/ksync/doctor"
 )
 
 type createCmd struct {
@@ -133,10 +133,12 @@ func (cmd *createCmd) run(_ *cobra.Command, args []string) {
 		log.Fatalf("Could not create, --force to ignore: %v", err)
 	}
 
-	if err := doctor.IsWatchRunning(); err != nil {
+	// Before writing the config to disk, check to make sure syncthing is up
+	// TODO: HOTFIX
+	if err := doctor.IsSyncthingReady(); err != nil {
 		log.Fatal(err)
 	}
-	
+
 	if err := specs.Save(); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/ksync/doctor/local.go
+++ b/pkg/ksync/doctor/local.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/vapor-ware/ksync/pkg/ksync"
+	"github.com/vapor-ware/ksync/pkg/syncthing"
 )
 
 var (
@@ -53,6 +54,25 @@ func IsWatchRunning() error {
 	}
 
 	if err := conn.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsSyncthingReady checks to see if syncthing is alive and accepting requests
+// TODO: HOTFIX
+func IsSyncthingReady() error {
+	server, err := syncthing.NewServer(fmt.Sprintf("localhost:%d",
+		viper.GetInt("syncthing-port")),
+		viper.GetString("apikey"))
+
+	if err != nil {
+		log.Warn(server)
+		return err
+	}
+
+	if _, err := server.IsAlive(); err != nil {
 		return err
 	}
 

--- a/pkg/syncthing/server.go
+++ b/pkg/syncthing/server.go
@@ -111,3 +111,14 @@ func (s *Server) Stop() {
 	<-s.stop
 	log.WithFields(s.Fields()).Debug("stopping")
 }
+
+// IsAlive checks the `ping` endpoint to see if syncthing is up
+// TODO: HOTFIX
+func (s *Server) IsAlive() (bool, error) {
+	time.Sleep(time.Second * 5) // Wait long enough to syncthing has gone down
+	if _, err := s.client.NewRequest().Get("system/ping"); err != nil { // nolint: megacheck
+		return false, err
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Adds a hotfix for multiple specs being created at once leading to a race condition.

Ultimately this should be solved more gracefully.

Closes #145 
Closes #160 