### PR TITLE
Allow semver 2.0 "pre-release" tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,4 +181,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]*(\.[0-9]*)*$/
+              only: /^[0-9]*(\.[0-9]*)*(-(\S)*)?$/


### PR DESCRIPTION
Allow for `-` "pre-release" style tags to also be recognized by CI for the release workflow.

https://semver.org/