### PR TITLE
Parallelism In CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,6 @@ jobs:
             - vendor-{{ checksum "Gopkg.toml" }}
 
       - run:
-          name: "Make test report directory"
-          command: mkdir -p /tmp/$TEST_DIRECTORY
-
-      - run:
           name: "Installing Vendored Dependencies"
           command: |
             go get -v github.com/golang/dep/cmd/dep
@@ -70,24 +66,9 @@ jobs:
             testdata/ci/setup.sh
 
       - run:
-          name: "Lint"
-          command: |
-            make lint
-
-      - run:
           name: "Launch Required Objects Into Cluster"
           command: |
             testdata/ci/launch.sh
-
-      - run:
-          name: "Get test to junit xml parser"
-          command: |
-            go get -v -u github.com/jstemmer/go-junit-report
-
-      - run:
-          name: "Running Tests"
-          command: |
-            make ci-test
 
       - run:
           name: "Building"
@@ -108,6 +89,61 @@ jobs:
       - store_artifacts:
           path: bin
           destination: binaries
+
+  lint:
+    resource_class: large
+    docker:
+      - image: circleci/golang:latest
+        environment:
+          DEBUG: true
+
+    working_directory: /go/src/github.com/vapor-ware/ksync
+
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: "Lint"
+          command: |
+            make lint
+
+  test:
+    resource_class: large
+    docker:
+      - image: circleci/golang:latest
+        environment:
+          DEBUG: true
+
+    working_directory: /go/src/github.com/vapor-ware/ksync
+
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: "Make test report directory"
+          command: mkdir -p /tmp/$TEST_DIRECTORY
+
+      - run:
+          name: "Get test to junit xml parser"
+          command: |
+            go get -v -u github.com/jstemmer/go-junit-report
+
+      - run:
+          name: "Running Tests"
+          command: |
+            make ci-test
 
       - store_test_results:
           path: /tmp/gotest
@@ -165,9 +201,21 @@ jobs:
 workflows:
   version: 2
 
-  release:
+  github-push:
     jobs:
       - build:
+          context: org-global
+          filters:
+            tags:
+              only: /.*/
+
+      - lint:
+          context: org-global
+          filters:
+            tags:
+              only: /.*/
+
+      - test:
           context: org-global
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,104 @@ jobs:
     working_directory: /go/src/github.com/vapor-ware/ksync
 
     environment:
-        TEST_DIRECTORY: "gotest"
         BINARY_NAME: "ksync"
-        CLUSTER_NAME: "tim-dev"
-        CLUSTER_ZONE: "us-central1-b"
 
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
 
       - checkout
+
+      - restore_cache:
+          keys:
+            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+            - vendor-{{ checksum "Gopkg.toml" }}
+
+      - run:
+          name: "Installing Vendored Dependencies"
+          command: |
+            go get -v github.com/golang/dep/cmd/dep
+            go install github.com/golang/dep/cmd/dep
+            dep ensure -v --vendor-only
+
+      - run:
+          name: "Building"
+          command: |
+            make build-ci OPTS='-os="!netbsd !freebsd !openbsd" -arch="amd64"'
+
+      - save_cache:
+          when: on_success
+          key: vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+          paths:
+            - vendor/
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bin
+
+      - store_artifacts:
+          path: bin
+          destination: binaries
+
+  lint:
+    resource_class: large
+    docker:
+      - image: circleci/golang:latest
+        environment:
+          DEBUG: true
+
+    working_directory: /go/src/github.com/vapor-ware/ksync
+
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - attach_workspace:
+          at: .
+
+
+      - restore_cache:
+          keys:
+            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+            - vendor-{{ checksum "Gopkg.toml" }}
+
+      - run:
+          name: "Installing Vendored Dependencies"
+          command: |
+            go get -v github.com/golang/dep/cmd/dep
+            go install github.com/golang/dep/cmd/dep
+            dep ensure -v --vendor-only
+
+      - run:
+          name: "Lint"
+          command: |
+            make lint
+
+  test:
+    resource_class: large
+    docker:
+      - image: circleci/golang:latest
+        environment:
+          DEBUG: true
+
+    working_directory: /go/src/github.com/vapor-ware/ksync
+
+    environment:
+        TEST_DIRECTORY: "gotest"
+        CLUSTER_NAME: "tim-dev"
+        CLUSTER_ZONE: "us-central1-b"
+
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - attach_workspace:
+          at: .
 
       - restore_cache:
           keys:
@@ -69,93 +157,6 @@ jobs:
           name: "Launch Required Objects Into Cluster"
           command: |
             testdata/ci/launch.sh
-
-      - run:
-          name: "Building"
-          command: |
-            make build-ci OPTS='-os="!netbsd !freebsd !openbsd" -arch="amd64"'
-
-      - save_cache:
-          when: on_success
-          key: vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
-          paths:
-            - vendor/
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - bin
-
-      - store_artifacts:
-          path: bin
-          destination: binaries
-
-  lint:
-    resource_class: large
-    docker:
-      - image: circleci/golang:latest
-        environment:
-          DEBUG: true
-
-    working_directory: /go/src/github.com/vapor-ware/ksync
-
-    steps:
-      - checkout
-
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - attach_workspace:
-          at: .
-
-
-      - restore_cache:
-          keys:
-            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
-            - vendor-{{ checksum "Gopkg.toml" }}
-
-      # - run:
-      #     name: "Installing Vendored Dependencies"
-      #     command: |
-      #       go get -v github.com/golang/dep/cmd/dep
-      #       go install github.com/golang/dep/cmd/dep
-      #       dep ensure -v --vendor-only
-
-      - run:
-          name: "Lint"
-          command: |
-            make lint
-
-  test:
-    resource_class: large
-    docker:
-      - image: circleci/golang:latest
-        environment:
-          DEBUG: true
-
-    working_directory: /go/src/github.com/vapor-ware/ksync
-
-    steps:
-      - checkout
-
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - attach_workspace:
-          at: .
-
-      - restore_cache:
-          keys:
-            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
-            - vendor-{{ checksum "Gopkg.toml" }}
-
-      - run:
-          name: "Installing Vendored Dependencies"
-          command: |
-            go get -v github.com/golang/dep/cmd/dep
-            go install github.com/golang/dep/cmd/dep
-            dep ensure -v --vendor-only
-
 
       - run:
           name: "Make test report directory"
@@ -230,6 +231,9 @@ workflows:
   github-push:
     jobs:
       - build:
+          requires:
+            - lint
+            - test
           context: org-global
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,19 @@ jobs:
       - attach_workspace:
           at: .
 
+
+      - restore_cache:
+          keys:
+            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+            - vendor-{{ checksum "Gopkg.toml" }}
+
+      # - run:
+      #     name: "Installing Vendored Dependencies"
+      #     command: |
+      #       go get -v github.com/golang/dep/cmd/dep
+      #       go install github.com/golang/dep/cmd/dep
+      #       dep ensure -v --vendor-only
+
       - run:
           name: "Lint"
           command: |
@@ -130,6 +143,19 @@ jobs:
 
       - attach_workspace:
           at: .
+
+      - restore_cache:
+          keys:
+            - vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}
+            - vendor-{{ checksum "Gopkg.toml" }}
+
+      - run:
+          name: "Installing Vendored Dependencies"
+          command: |
+            go get -v github.com/golang/dep/cmd/dep
+            go install github.com/golang/dep/cmd/dep
+            dep ensure -v --vendor-only
+
 
       - run:
           name: "Make test report directory"
@@ -195,7 +221,7 @@ jobs:
           command: |
             for DISTRO in linux darwin
             do
-              curl -F file=@bin/${BINARY_NAME}_${DISTRO}_amd64 -F channels=${SLACK_CHANNEL} -F token=${SLACK_TOKEN} -F filename=${BINARY_NAME} -F filetype=binary -F title="${BINARY_NAME} ${CIRCLE_TAG} ${DISTRO}" https://slack.com/api/files.upload
+              curl --progress-bar -F file=@bin/${BINARY_NAME}_${DISTRO}_amd64 -F channels=${SLACK_CHANNEL} -F token=${SLACK_TOKEN} -F filename=${BINARY_NAME} -F filetype=binary -F title="${BINARY_NAME} ${CIRCLE_TAG} ${DISTRO}" https://slack.com/api/files.upload
             done
 
 workflows:
@@ -224,6 +250,8 @@ workflows:
       - release:
           requires:
             - build
+            - lint
+            - test
           context: org-global
           filters:
             branches:


### PR DESCRIPTION
Technically this isn't parallelism (defined [here](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-filesize)) because most of our long running processes are linear and can't be split. However, we can split out the various (relatively) independent jobs so that they run in parallel.

Closes #184 