### PR TITLE
Fixes #194

### DIFF
--- a/cmd/ksync/get.go
+++ b/cmd/ksync/get.go
@@ -154,7 +154,7 @@ func (g *getCmd) run(cmd *cobra.Command, args []string) {
 		for s := range resp.Items {
 			fmt.Printf("%s\n", s)
 		}
-	} else if g.Viper.GetString("output") == "json" {
+	} else if viper.GetString("output") == "json" {
 		marshaller := &jsonpb.Marshaler{
 			Indent: "	",
 			EnumsAsInts: true,


### PR DESCRIPTION
Moving this flag to the global flag list changed `viper` instance it was attached to.