### PR TITLE
If args are submitted to `get` search on those terms.

### DIFF
--- a/cmd/ksync/get.go
+++ b/cmd/ksync/get.go
@@ -53,7 +53,7 @@ func (g *getCmd) new() *cobra.Command {
 	return g.Cmd
 }
 
-func (g *getCmd) out(specs *pb.SpecList) {
+func (g *getCmd) out(specs *pb.SpecList) { // nolint: gocyclo
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/ksync/get.go
+++ b/cmd/ksync/get.go
@@ -71,6 +71,13 @@ func (g *getCmd) out(specs *pb.SpecList) {
 	sort.Strings(keys)
 
 	for _, name := range keys {
+		if len(g.Cmd.Flags().Args()) != 0 {
+			for search := range g.Cmd.Flags().Args() {
+				if !strings.Contains(name, g.Cmd.Flags().Arg(search)) {
+					continue
+				}
+			}
+		}
 		spec := specs.Items[name]
 
 		status := spec.Status

--- a/cmd/ksync/get.go
+++ b/cmd/ksync/get.go
@@ -70,11 +70,12 @@ func (g *getCmd) out(specs *pb.SpecList) { // nolint: gocyclo
 	}
 	sort.Strings(keys)
 
+	sort:
 	for _, name := range keys {
 		if len(g.Cmd.Flags().Args()) != 0 {
 			for search := range g.Cmd.Flags().Args() {
 				if !strings.Contains(name, g.Cmd.Flags().Arg(search)) {
-					continue
+					continue sort
 				}
 			}
 		}


### PR DESCRIPTION
Closes #200

Simple string matching search based on spec names.