### PR TITLE
Daemon update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -580,6 +580,14 @@
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:05dc5c00381eccf0bbc07717248b8757e0e9318877e15e09316fac9b72f1b3ef"
+  name = "github.com/sevlyar/go-daemon"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f9261e73885de99b1647d68bedadf2b9a99ad11f"
+  version = "v0.1.4"
+
+[[projects]]
   digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -1048,6 +1056,7 @@
     "github.com/olekukonko/tablewriter",
     "github.com/phayes/permbits",
     "github.com/pkg/errors",
+    "github.com/sevlyar/go-daemon",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cast",
     "github.com/spf13/cobra",

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ci-test:
 HAS_LINT := $(shell command -v gometalinter)
 
 .PHONY: lint
-lint: install-linter most-lint megacheck
+lint: install-linter most-lint
 
 .PHONY: install-linter
 install-linter:
@@ -159,25 +159,10 @@ most-lint:
 		--skip "testdata" \
 		--exclude "[a-zA-Z]*_test.go" \
 		--exclude "[a-zA-Z]*.pb.go" \
-		--disable=megacheck \
 		--tests \
 		--sort=severity \
 		--aggregate \
 		--deadline=500s
-
-.PHONY: megacheck
-megacheck:
-	gometalinter ./... \
-		--vendor \
-		--skip "testdata" \
-		--exclude "[a-zA-Z]*_test.go" \
-		--exclude "[a-zA-Z]*.pb.go" \
-		--disable-all \
-		--tests \
-		--sort=severity \
-		--aggregate \
-		--enable=megacheck \
-		--deadline=240s
 
 HAS_STERN := $(shell command -v stern)
 

--- a/cmd/ksync/daemon.go
+++ b/cmd/ksync/daemon.go
@@ -3,7 +3,7 @@ package main
 import (
 	"path/filepath"
 
-	daemon "github.com/timfallmk/go-daemon"
+	daemon "github.com/sevlyar/go-daemon"
 
 	"github.com/vapor-ware/ksync/pkg/cli"
 )

--- a/pkg/input/sync_path.go
+++ b/pkg/input/sync_path.go
@@ -25,7 +25,7 @@ func GetSyncPath(args []string) SyncPath {
 
 // localPathHasPermission checks a given root directory, and all children, for
 // `rw` permissions for the current user.
-func (s *SyncPath) localPathHasPermission() error { // nolint: megacheck
+func (s *SyncPath) localPathHasPermission() error { // nolint: staticcheck
 	root, err := filepath.Abs(s.Local)
 	if err != nil {
 		return err
@@ -38,9 +38,9 @@ func (s *SyncPath) localPathHasPermission() error { // nolint: megacheck
 
 		switch {
 		case !permissions.UserRead():
-			return fmt.Errorf("File %s is not readable. It is set to %v", path, permissions)
+			return fmt.Errorf("File %s is not readable. It is set to %v", path, permissions) // nolint: staticcheck
 		case !permissions.UserWrite():
-			return fmt.Errorf("File %s is not writable. It is set to %v", path, permissions)
+			return fmt.Errorf("File %s is not writable. It is set to %v", path, permissions) // nolint: staticcheck
 		}
 
 		return nil

--- a/pkg/ksync/cluster/connection.go
+++ b/pkg/ksync/cluster/connection.go
@@ -45,7 +45,7 @@ func (c *Connection) Fields() log.Fields {
 
 func (c *Connection) opts() []grpc.DialOption {
 	return []grpc.DialOption{
-		grpc.WithTimeout(5 * time.Second), // nolint: megacheck
+		grpc.WithTimeout(5 * time.Second), // nolint: staticcheck
 		grpc.WithBlock(),
 		grpc.WithInsecure(),
 	}

--- a/pkg/ksync/doctor/local.go
+++ b/pkg/ksync/doctor/local.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/vapor-ware/ksync/pkg/proto"
 )
 
+// nolint: staticcheck
 var (
 	errWatchNotRunning     = fmt.Errorf(`It appears that watch isn't running. You can start it with 'ksync watch'`)
 	errWatchNotResponding  = fmt.Errorf(`It appears that watch isn't responding`)

--- a/pkg/ksync/folder.go
+++ b/pkg/ksync/folder.go
@@ -133,7 +133,7 @@ func (f *Folder) initRadarClient() error {
 
 func (f *Folder) initKsyncClient() error {
 	conn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", viper.GetInt("port")),
-		grpc.WithTimeout(5*time.Second), // nolint: megacheck
+		grpc.WithTimeout(5*time.Second), // nolint: staticcheck
 		grpc.WithBlock(),
 		grpc.WithInsecure())
 	if err != nil {

--- a/pkg/ksync/server/restart.go
+++ b/pkg/ksync/server/restart.go
@@ -37,7 +37,7 @@ func (k *ksyncServer) IsAlive(ctx context.Context, _ *empty.Empty) (*pb.Alive, e
 	case false:
 		return &pb.Alive{Alive: false}, nil
 	}
-	return &pb.Alive{Alive: false}, fmt.Errorf("Error during liveness check")
+	return &pb.Alive{Alive: false}, fmt.Errorf("Error during liveness check") // nolint: staticcheck
 }
 
 func (k *ksyncServer) debounce(ctx context.Context, _ *empty.Empty, t time.Duration) {

--- a/pkg/ksync/syncthing.go
+++ b/pkg/ksync/syncthing.go
@@ -219,7 +219,7 @@ func (s *Syncthing) Run() error {
 	// This is horrific, but spin off a process to check for signals about LOS
 	// (Loss Of Signal) from the cluster. Cleanup and bail if we get one.
 	go func() {
-		for { // nolint: megacheck
+		for { // nolint: staticcheck
 			select {
 			case <-SignalLoss:
 				log.WithFields(s.Fields()).Info("signal loss dectected. shutting down")

--- a/pkg/syncthing/server.go
+++ b/pkg/syncthing/server.go
@@ -101,7 +101,7 @@ func (s *Server) Update() error {
 // Restart rolls the remote server. Because of how syncthing runs, this just
 // happens in the background with only minimal interruption.
 func (s *Server) Restart() error {
-	if _, err := s.client.NewRequest().Post("system/restart"); err != nil { // nolint: megacheck
+	if _, err := s.client.NewRequest().Post("system/restart"); err != nil { // nolint: staticcheck
 		return err
 	}
 


### PR DESCRIPTION
Update the daemon package from timfallmk/go-daemon to the upstream sevlyar/go-daemon which adds support for Windows.

Closes #256 

**Warning**: Only tested building on Windows. Functionality is experimental and untested.