### PR TITLE
Fixing a small bug with non-default Docker roots

### DIFF
--- a/cmd/ksync/clean.go
+++ b/cmd/ksync/clean.go
@@ -88,7 +88,7 @@ func (c *cleanCmd) fromOrbit() {
 	log.WithFields(log.Fields{
 		"path":  viper.ConfigFileUsed(),
 		"files": files,
-	}).Info("Nuking all files from from orbit. It's the only way.")
+	}).Info("Nuking all files from orbit. It's the only way.")
 	if err := os.RemoveAll(cli.ConfigPath()); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/ksync/ksync.go
+++ b/cmd/ksync/ksync.go
@@ -145,6 +145,19 @@ func remoteFlags(flags *pflag.FlagSet) {
 		log.Fatal(err)
 	}
 
+	flags.String(
+		"docker-socket",
+		"/var/run/docker.sock",
+		"path to the docker socket")
+	if err := flags.MarkHidden("docker-socket"); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := cli.BindFlag(
+		viper.GetViper(), flags.Lookup("docker-socket"), "ksync"); err != nil {
+
+		log.Fatal(err)
+	}
 }
 
 func init() {

--- a/cmd/ksync/ksync.go
+++ b/cmd/ksync/ksync.go
@@ -88,7 +88,7 @@ func localFlags(flags *pflag.FlagSet) {
 	}
 }
 
-func remoteFlags(flags *pflag.FlagSet) {
+func remoteFlags(flags *pflag.FlagSet) { //nolint: gocyclo
 	flags.String(
 		"image",
 		fmt.Sprintf("vaporio/ksync:git-%s", ksync.GitCommit),

--- a/pkg/ksync/cluster/daemon_set.go
+++ b/pkg/ksync/cluster/daemon_set.go
@@ -53,7 +53,7 @@ func (s *Service) daemonSet() *v1beta1.DaemonSet {
 							VolumeMounts: []v1.VolumeMount{
 								v1.VolumeMount{
 									Name:      "dockersock",
-									MountPath: "/var/run/docker.sock",
+									MountPath: viper.GetString("docker-socket"),
 								},
 							},
 						},
@@ -79,7 +79,7 @@ func (s *Service) daemonSet() *v1beta1.DaemonSet {
 								},
 								v1.VolumeMount{
 									Name:      "dockersock",
-									MountPath: "/var/run/docker.sock",
+									MountPath: viper.GetString("docker-socket"),
 								},
 								v1.VolumeMount{
 									Name:      "kubelet",
@@ -113,7 +113,7 @@ func (s *Service) daemonSet() *v1beta1.DaemonSet {
 							Name: "dockerfs",
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
-									Path: "/var/lib/docker",
+									Path: viper.GetString("docker-root"),
 								},
 							},
 						},
@@ -121,7 +121,7 @@ func (s *Service) daemonSet() *v1beta1.DaemonSet {
 							Name: "dockersock",
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
-									Path: "/var/run/docker.sock",
+									Path: viper.GetString("docker-socket"),
 								},
 							},
 						},

--- a/pkg/ksync/cluster/service_test.go
+++ b/pkg/ksync/cluster/service_test.go
@@ -16,6 +16,8 @@ func init() {
 
 	// Set the default for `docker-root` so it's evaluated properly in the daemon set template during testing
 	viper.Set("docker-root", "/var/lib/docker")
+	// and same for docker-sock
+	viper.Set("docker-socket", "/var/run/docker.sock")
 }
 
 func TestNewRadarInstance(t *testing.T) {


### PR DESCRIPTION
And also allowing to pass custom paths to Docker sockets.

Both come in handy when using
https://github.com/kubernetes-sigs/kubeadm-dind-cluster

Signed-off-by: Jean Rouge <rougej+github@gmail.com>