### PR TITLE
Fatal in case of radar connection error

### DIFF
--- a/pkg/ksync/cluster/connection.go
+++ b/pkg/ksync/cluster/connection.go
@@ -96,7 +96,7 @@ func (c *Connection) connection(port int32) (int32, error) {
 func (c *Connection) Radar() (*grpc.ClientConn, error) {
 	localPort, err := c.connection(c.service.RadarPort)
 	if err != nil {
-		return nil, debug.ErrorLocation(err)
+		log.Fatal(err)
 	}
 
 	return grpc.Dial(fmt.Sprintf("127.0.0.1:%d", localPort), c.opts()...)


### PR DESCRIPTION
Solves https://github.com/vapor-ware/ksync/issues/310

This will fail ksync in case of this error, as it is anyway not recoverable.